### PR TITLE
Dockerfile: use Python 3.12 & update example run-cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,13 +47,13 @@
 #
 # $ docker run \
 #     --name "cdcagg_client" \
-#     --mount source=xml_sources,destination=/xml_sources,readonly \
-#     --mount source=app_data,destination=/app_data \
+#     --mount type=bind,source=./xml_sources,destination=/xml_sources,readonly \
+#     --mount type=bind,source=./app_data,destination=/app_data \
 #     -e "CDCAGG_DS_URL=http://153.1.61.18:5001/v0" \
 #     cdcagg-client
 #
 
-FROM python:3.9-slim as builder
+FROM python:3.12-slim AS builder
 
 COPY . /docker-build
 WORKDIR /docker-build
@@ -73,7 +73,7 @@ RUN --mount=type=secret,id=bbcreds \
 # END FIRST STAGE
 
 
-FROM python:3.9-slim as prod
+FROM python:3.12-slim AS prod
 
 # Copy build packages from builder image to prod.
 # Add them to PATH.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,8 +71,9 @@ node(node_label) {
                 """
             }
             stage('Publish Cobertura Report') {
-                cobertura(coberturaReportFile: "${coverage_xml_path}",
-                          zoomCoverageChart: false)
+                recordCoverage(tools: [[parser: 'COBERTURA',
+                                        pattern:  "${coverage_xml_path}"]],
+                               sourceCodeRetention: 'LAST_BUILD')
             }
             stage('Clean up tox-env') {
                 if (fileExists(toxEnvName)) {


### PR DESCRIPTION
This PR also switches Jenkins-plugin cobertura to recordCoverage to keep track of test coverage and display it in Jenkins.